### PR TITLE
캘린더 화면에서 요일을 표시하기 위한 `CalendarWeek` UI를 추가합니다.

### DIFF
--- a/library-calendar/src/main/java/com/inseoul/library_calendar/CalendarWeek.kt
+++ b/library-calendar/src/main/java/com/inseoul/library_calendar/CalendarWeek.kt
@@ -1,0 +1,40 @@
+package com.inseoul.library_calendar
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Divider
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun CalendarWeek(modifier: Modifier) {
+    Column(
+        modifier = modifier.padding(top = 32.dp)
+    ) {
+        Row {
+           weeks.forEach {
+               Text(
+                   text = it,
+                   fontSize = 16.sp,
+                   modifier = Modifier.weight(weight = 1f),
+                   textAlign = TextAlign.Center
+               )
+           }
+        }
+        Divider(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 16.dp),
+            color = Color.Blue, // NOTE : 임시로 BLUE 값 지정
+        )
+    }
+}
+
+private val weeks: List<String> = listOf("일", "월", "화", "수", "목", "금", "토")


### PR DESCRIPTION
### 배경
- 캘린더 구현을 위해 Week를 추가합니다.

### 작업내용
- 커곧내

### 스크린샷

<img width="400" alt="스크린샷 2022-08-17 오전 10 55 29" src="https://user-images.githubusercontent.com/52733201/205503147-5486af1e-366c-42a8-8267-47628103f847.png">

### 리뷰노트
- PR 분리로 #6 PR이 선머지 되어야합니다.
