### PR TITLE
디자인 시스템 모듈에 공용으로 사용할 Switch, TextField UI를 추가합니다

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,29 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="PreviewAnnotationInFunctionWithParameters" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewFontScaleMustBeGreaterThanZero" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewMultipleParameterProviders" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewMustBeTopLevelFunction" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewNeedsComposableAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewNotSupportedInUnitTestFiles" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewPickerAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+  </profile>
+</component>

--- a/core/designsystem/src/main/java/com/inseoul/designsystem/icon/InseoulIcons.kt
+++ b/core/designsystem/src/main/java/com/inseoul/designsystem/icon/InseoulIcons.kt
@@ -1,0 +1,22 @@
+package com.inseoul.designsystem.icon
+
+import com.inseoul.designsystem.R
+
+object InseoulIcons {
+    val ArrowBack = R.drawable.icon_arrow_back
+    val ArrowDecreaseMono = R.drawable.icon_arrow_decrease_mono
+    val ArrowIncreaseMono = R.drawable.icon_arrow_increase_mono
+    val ArrowLeft = R.drawable.icon_arrow_left
+    val ArrowRight = R.drawable.icon_arrow_right
+    val Bell = R.drawable.icon_bell
+    val CalendarCheckMono = R.drawable.icon_calendar_check_mono
+    val CheckFill = R.drawable.icon_check_fill
+    val ClockMono = R.drawable.icon_clock_mono
+    val PencilMono = R.drawable.icon_pencil_mono
+    val Pets = R.drawable.icon_pets
+    val PlayMono = R.drawable.icon_play_mono
+    val SettingMono = R.drawable.icon_setting_mono
+    val StarMono = R.drawable.icon_star_mono
+    val UserMono = R.drawable.icon_user_mono
+    val XCircleMono = R.drawable.icon_x_circle_mono
+}

--- a/core/designsystem/src/main/java/com/inseoul/designsystem/switchbutton/InseoulSwitch.kt
+++ b/core/designsystem/src/main/java/com/inseoul/designsystem/switchbutton/InseoulSwitch.kt
@@ -21,10 +21,9 @@ import com.inseoul.designsystem.theme.gray300
 
 @Composable
 fun InseoulSwitch(
-    scale: Float = 2f,
-    width: Dp = 52.dp,
-    height: Dp = 32.dp,
-    gapBetweenThumbAndTrackEdge: Dp = 4.dp
+    width: Dp,
+    height: Dp,
+    gapBetweenThumbAndTrackEdge: Dp
 ) {
     val switchOn = remember { mutableStateOf(false) }
     val thumbRadius = (height / 2) - gapBetweenThumbAndTrackEdge
@@ -37,7 +36,6 @@ fun InseoulSwitch(
 
     Canvas(modifier = Modifier
         .size(width, height)
-        .scale(scale = scale)
         .pointerInput(Unit) {
             detectTapGestures(
                 onTap = {
@@ -47,9 +45,7 @@ fun InseoulSwitch(
         }
     ) {
         drawRoundRect(
-            color = if (switchOn.value) {
-                Green300
-            } else gray300,
+            color = if (switchOn.value) Green300 else gray300,
             cornerRadius = CornerRadius(x = 100.dp.toPx(), y = 100.dp.toPx()),
         )
         drawCircle(

--- a/core/designsystem/src/main/java/com/inseoul/designsystem/switchbutton/InseoulSwitch.kt
+++ b/core/designsystem/src/main/java/com/inseoul/designsystem/switchbutton/InseoulSwitch.kt
@@ -1,0 +1,64 @@
+package com.inseoul.designsystem.switchbutton
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.inseoul.designsystem.theme.Green300
+import com.inseoul.designsystem.theme.gray00
+import com.inseoul.designsystem.theme.gray300
+
+@Composable
+fun InseoulSwitch(
+    scale: Float = 2f,
+    width: Dp = 52.dp,
+    height: Dp = 32.dp,
+    gapBetweenThumbAndTrackEdge: Dp = 4.dp
+) {
+    val switchOn = remember { mutableStateOf(false) }
+    val thumbRadius = (height / 2) - gapBetweenThumbAndTrackEdge
+    val animatePosition = animateFloatAsState(
+        targetValue = if (switchOn.value)
+            with(LocalDensity.current) { (width - thumbRadius - gapBetweenThumbAndTrackEdge).toPx() }
+        else
+            with(LocalDensity.current) { (thumbRadius + gapBetweenThumbAndTrackEdge).toPx() }
+    )
+
+    Canvas(modifier = Modifier
+        .size(width, height)
+        .scale(scale = scale)
+        .pointerInput(Unit) {
+            detectTapGestures(
+                onTap = {
+                    switchOn.value = !switchOn.value
+                }
+            )
+        }
+    ) {
+        drawRoundRect(
+            color = if (switchOn.value) {
+                Green300
+            } else gray300,
+            cornerRadius = CornerRadius(x = 100.dp.toPx(), y = 100.dp.toPx()),
+        )
+        drawCircle(
+            color = gray00,
+            radius = thumbRadius.toPx(),
+            center = Offset(
+                x = animatePosition.value,
+                y = size.height / 2
+            )
+        )
+    }
+}

--- a/core/designsystem/src/main/java/com/inseoul/designsystem/textfield/InseoulTextField.kt
+++ b/core/designsystem/src/main/java/com/inseoul/designsystem/textfield/InseoulTextField.kt
@@ -1,0 +1,48 @@
+package com.inseoul.designsystem.textfield
+
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.Icon
+import androidx.compose.material.OutlinedTextField
+import androidx.compose.material.Text
+import androidx.compose.material.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.unit.dp
+import com.inseoul.designsystem.icon.InseoulIcons
+
+@Composable
+fun InseoulTextField(
+    modifier: Modifier = Modifier,
+    label: String,
+    placeholder: String,
+) {
+    val text = remember { mutableStateOf(TextFieldValue("")) }
+    OutlinedTextField(
+        modifier = modifier
+            .width(328.dp)
+            .height(60.dp),
+        value = text.value,
+        onValueChange = { text.value = it },
+        label = { Text(label) },
+        placeholder = { Text(placeholder) },
+        colors = TextFieldDefaults.outlinedTextFieldColors(
+            focusedBorderColor = Color.Black,
+            unfocusedBorderColor = Color.Black,
+            focusedLabelColor = Color.Black,
+            cursorColor = Color.Black
+        ),
+        trailingIcon = {
+            if (text.value.text.isNotEmpty())
+                Icon(
+                    painter = painterResource(id = InseoulIcons.XCircleMono),
+                    contentDescription = null
+                )
+        }
+    )
+}


### PR DESCRIPTION
### 배경
- 공용으로 사용하게 될 스위치 버튼, TextField를 구현하고자 디자인 시스템 모듈에서 작업을 진행하게 되었습니다.

### 작업내용
- 공용으로 사용하게 될 스위치 버튼 구현 
- 공용으로 사용하게 될 TextField를 구현
- Icon의 사용을 좀 더 쉽게 할 수 있게끔 Icon을 모아둔 InseoulIcons.kt 를 생성

### 스크린샷
![스크린샷 2022-12-08 오후 1 44 57](https://user-images.githubusercontent.com/70066242/206433559-61c4e013-dcb0-47f7-8744-97d6e7cdbc0b.png)
![스크린샷 2022-12-08 오후 1 45 01](https://user-images.githubusercontent.com/70066242/206433602-89335e60-55d3-45a1-9193-d224ae8df4b3.png)
![스크린샷 2022-12-08 오후 6 47 13](https://user-images.githubusercontent.com/70066242/206433624-d375fad5-885c-478f-871b-386debd1d5ec.png)

### 리뷰노트
- Compose에서 제공하는 Switch를 사용하여 구현해보려 하였지만, 피그마에 있는 디자인대로 스위치 버튼 만드는 것이 어려움을 파악하고 Canvas를 사용하여 구현하였습니다
- ``` InseoulIcons.XCircleMono ``` 와 같은 형식으로 InseoulIcons.kt에서 원하는 Icon을 가져와서 사용할 수 있습니다.