### PR TITLE
`CalendarScreen` UI를 호출하면 캘린더를 볼 수 있습니다.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,16 +2,18 @@ plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android'
     id 'com.google.gms.google-services'
+    id 'kotlin-kapt'
+    id 'com.google.dagger.hilt.android'
 }
 
 android {
     namespace 'com.inseoul.onetwothree'
-    compileSdk 32
+    compileSdk 33
 
     defaultConfig {
         applicationId "com.inseoul.onetwothree"
         minSdk 23
-        targetSdk 32
+        targetSdk 33
         versionCode 1
         versionName "1.0"
 
@@ -45,9 +47,13 @@ android {
             excludes += '/META-INF/{AL2.0,LGPL2.1}'
         }
     }
+    kapt {
+        correctErrorTypes true
+    }
 }
 
 dependencies {
+    implementation(project(":library-calendar"))
 
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.1'
@@ -65,4 +71,10 @@ dependencies {
     implementation platform('com.google.firebase:firebase-bom:31.1.0')
     implementation 'com.google.firebase:firebase-messaging'
     implementation 'com.google.firebase:firebase-analytics'
+
+    implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.5.1"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-compose:2.5.1"
+
+    implementation "com.google.dagger:hilt-android:2.44"
+    kapt "com.google.dagger:hilt-compiler:2.44"
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <application
+        android:name=".InseoulApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/com/inseoul/onetwothree/InseoulApplication.kt
+++ b/app/src/main/java/com/inseoul/onetwothree/InseoulApplication.kt
@@ -1,0 +1,7 @@
+package com.inseoul.onetwothree
+
+import android.app.Application
+import dagger.hilt.android.HiltAndroidApp
+
+@HiltAndroidApp
+class InseoulApplication : Application()

--- a/build.gradle
+++ b/build.gradle
@@ -8,4 +8,5 @@ plugins {
     id 'com.android.library' version '7.3.1' apply false
     id 'org.jetbrains.kotlin.android' version '1.6.10' apply false
     id 'com.google.gms.google-services' version '4.3.14' apply false
+    id 'com.google.dagger.hilt.android' version '2.44' apply false
 }

--- a/library-calendar/build.gradle
+++ b/library-calendar/build.gradle
@@ -1,15 +1,17 @@
 plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
+    id 'kotlin-kapt'
+    id 'com.google.dagger.hilt.android'
 }
 
 android {
     namespace 'com.inseoul.library_calendar'
-    compileSdk 32
+    compileSdk 33
 
     defaultConfig {
         minSdk 23
-        targetSdk 32
+        targetSdk 33
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -34,16 +36,27 @@ android {
     composeOptions {
         kotlinCompilerExtensionVersion '1.1.1'
     }
+    kapt {
+        correctErrorTypes true
+    }
 }
 
 dependencies {
+    implementation 'androidx.lifecycle:lifecycle-runtime-compose:2.6.0-alpha03'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.4'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.0'
 
     implementation 'androidx.core:core-ktx:1.7.0'
-    implementation 'androidx.compose.material:material:1.1.1'
+     implementation 'androidx.compose.material:material:1.3.1'
 
     implementation "androidx.compose.ui:ui:$compose_ui_version"
     implementation "androidx.compose.ui:ui-tooling-preview:$compose_ui_version"
+
+    implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.5.1"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-compose:2.5.1"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.0-alpha03"
+
+    implementation "com.google.dagger:hilt-android:2.44"
+    kapt "com.google.dagger:hilt-compiler:2.44"
 }

--- a/library-calendar/src/main/java/com/inseoul/library_calendar/CalendarDay.kt
+++ b/library-calendar/src/main/java/com/inseoul/library_calendar/CalendarDay.kt
@@ -1,0 +1,29 @@
+package com.inseoul.library_calendar
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+
+/*NOTE
+디자인 시스템 모듈에 있는 컬러값을 사용하기 위해
+해당 모듈에서 core-designsystem 모듈을 추가하면 빌드 에러나오는데 원인을 모르겠음*/
+@Composable
+fun CalendarDay(
+    day: String,
+    isActivated: Boolean
+) {
+    Text(
+        modifier = Modifier.size(size = 40.dp),
+        text = day,
+        color = if (isActivated) {
+            Color(0xFF212124)
+        } else {
+            Color(0xFFD1D3D8)
+        },
+        textAlign = TextAlign.Center
+    )
+}

--- a/library-calendar/src/main/java/com/inseoul/library_calendar/CalendarHelper.kt
+++ b/library-calendar/src/main/java/com/inseoul/library_calendar/CalendarHelper.kt
@@ -47,6 +47,8 @@ class CalendarHelper {
 
     fun getCurrentCalendar(): String = "${getYear()}년 ${getMonth()}월 ${getDay()}일"
 
+    fun getCurrentYearAndMonth(): String = "${getYear()}년 ${getMonth()}월"
+
     fun getMaximumDay(): Int = calendar.getActualMaximum(Calendar.DATE)
 
     fun getCurrentWeekDay(): Int = calendar[Calendar.DAY_OF_WEEK]
@@ -86,5 +88,46 @@ class CalendarHelper {
 
             emptyWeekDayList.size - 1
         }
+    }
+
+    fun getLastDaysOfPreviousMonth(emptyCount: Int): List<Int> {
+        if (emptyCount <= 0) return emptyList()
+
+        val dayList = mutableListOf<Int>()
+        val newCalendar = Calendar.getInstance().apply {
+            set(Calendar.YEAR, getYear())
+            set(Calendar.MONTH, getMonth().minus(2))
+            setDay()
+        }
+        val maximumDay = newCalendar.getActualMaximum(Calendar.DATE)
+
+        if (emptyCount == 1) {
+            dayList.add(maximumDay)
+        } else {
+            for (i in maximumDay downTo maximumDay - (emptyCount -1)) {
+                dayList.add(i)
+            }
+        }
+
+        return if (dayList.size >= 2) {
+            dayList.reversed()
+        } else {
+            dayList
+        }
+    }
+
+    fun getFirstDaysOfNextMonth(emptyCount: Int): List<Int> {
+        if (emptyCount <= 0) return emptyList()
+
+        val dayList = mutableListOf<Int>()
+        if (emptyCount == 1) {
+            dayList.add(1)
+        } else {
+            for (i in 1..emptyCount) {
+                dayList.add(i)
+            }
+        }
+
+        return dayList
     }
 }

--- a/library-calendar/src/main/java/com/inseoul/library_calendar/CalendarScreen.kt
+++ b/library-calendar/src/main/java/com/inseoul/library_calendar/CalendarScreen.kt
@@ -1,0 +1,45 @@
+package com.inseoul.library_calendar
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun CalendarScreen(
+    viewModel: CalendarViewModel
+) {
+    val toolbarTitle = viewModel.getCalendarToolbarTitle()
+    val currentCalendar = viewModel.getCalendarDays()
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(start = 16.dp, end = 16.dp)
+    ) {
+        CalendarToolbar(
+            title = toolbarTitle,
+            onPreviousClicked = {
+                // NOTE : 뒤로가기 클릭
+            },
+            onNextClicked = {
+                // NOTE : 앞으로 가기 클릭
+            }
+        )
+        CalendarWeek()
+        LazyVerticalGrid(
+            columns = GridCells.Fixed(7)
+        ) {
+            items(currentCalendar.size) {
+                CalendarDay(
+                    day = currentCalendar[it].day,
+                    isActivated = currentCalendar[it].isActivated
+                )
+            }
+        }
+    }
+}

--- a/library-calendar/src/main/java/com/inseoul/library_calendar/CalendarToolbar.kt
+++ b/library-calendar/src/main/java/com/inseoul/library_calendar/CalendarToolbar.kt
@@ -3,12 +3,15 @@ package com.inseoul.library_calendar
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 
@@ -20,7 +23,7 @@ fun CalendarToolbar(
     onNextClicked: () -> Unit
 ) {
     Row(
-        modifier = modifier,
+        modifier = modifier.padding(top = 16.dp, bottom = 24.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         Image(
@@ -35,7 +38,9 @@ fun CalendarToolbar(
         Text(
             modifier = Modifier.weight(1f),
             text = title,
-            textAlign = TextAlign.Center
+            textAlign = TextAlign.Center,
+            color = Color(0xFF212124),
+            fontWeight = FontWeight.Bold
         )
         Image(
             modifier = Modifier

--- a/library-calendar/src/main/java/com/inseoul/library_calendar/CalendarViewModel.kt
+++ b/library-calendar/src/main/java/com/inseoul/library_calendar/CalendarViewModel.kt
@@ -1,0 +1,55 @@
+package com.inseoul.library_calendar
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class CalendarViewModel @Inject() constructor() : ViewModel() {
+    private var calendarHelper = CalendarHelper()
+
+    private val days = mutableListOf<DayState>()
+
+    init {
+        initalized()
+    }
+
+    fun getCalendarDays(): List<DayState> = days
+
+    fun getCalendarToolbarTitle(): String = calendarHelper.getCurrentYearAndMonth()
+
+    private fun initalized() {
+        val currentDays = calendarHelper.createCalendar()
+        val firstWeekEmptyCount = getFirstWeekDayEmptyCount()
+        val lastWeekEmptyCount = getLastWeekDayEmptyCount()
+        val daysOfPreviousMonth = getLastDaysOfPreviousMonth(firstWeekEmptyCount)
+        val daysOfNextMonth = getFirstDaysOfNextMonth(lastWeekEmptyCount)
+
+        addDaysIfNeeded(daysOfPreviousMonth)
+        addDaysIfNeeded(currentDays, true)
+        addDaysIfNeeded(daysOfNextMonth)
+    }
+
+    private fun getLastWeekDayEmptyCount(): Int = calendarHelper.getLastWeekDayEmptyCount()
+
+    private fun getFirstWeekDayEmptyCount(): Int = calendarHelper.getFirstWeekDayEmptyCount()
+
+    private fun getLastDaysOfPreviousMonth(emptyCount: Int): List<Int> =
+        calendarHelper.getLastDaysOfPreviousMonth(emptyCount)
+
+    private fun getFirstDaysOfNextMonth(emptyCount: Int): List<Int> =
+        calendarHelper.getFirstDaysOfNextMonth(emptyCount)
+
+    private fun addDaysIfNeeded(dayList: List<Int>, isNeeded: Boolean = false) {
+        if (dayList.isEmpty()) return
+
+        dayList.forEach {
+            days.add(
+                DayState(
+                    day = it.toString(),
+                    isActivated = isNeeded
+                )
+            )
+        }
+    }
+}

--- a/library-calendar/src/main/java/com/inseoul/library_calendar/CalendarWeek.kt
+++ b/library-calendar/src/main/java/com/inseoul/library_calendar/CalendarWeek.kt
@@ -1,10 +1,7 @@
 package com.inseoul.library_calendar
 
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.Divider
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -14,26 +11,17 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
 @Composable
-fun CalendarWeek(modifier: Modifier) {
-    Column(
-        modifier = modifier.padding(top = 32.dp)
-    ) {
-        Row {
-           weeks.forEach {
-               Text(
-                   text = it,
-                   fontSize = 16.sp,
-                   modifier = Modifier.weight(weight = 1f),
-                   textAlign = TextAlign.Center
-               )
-           }
+fun CalendarWeek() {
+    Row(modifier = Modifier.padding(bottom = 16.dp)) {
+        weeks.forEach {
+            Text(
+                text = it,
+                fontSize = 16.sp,
+                modifier = Modifier.weight(weight = 1f),
+                textAlign = TextAlign.Center,
+                color = Color(0xFF868B94)
+            )
         }
-        Divider(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = 16.dp),
-            color = Color.Blue, // NOTE : 임시로 BLUE 값 지정
-        )
     }
 }
 

--- a/library-calendar/src/main/java/com/inseoul/library_calendar/DayState.kt
+++ b/library-calendar/src/main/java/com/inseoul/library_calendar/DayState.kt
@@ -1,0 +1,6 @@
+package com.inseoul.library_calendar
+
+data class DayState(
+    val day: String,
+    val isActivated: Boolean
+)


### PR DESCRIPTION
### 배경
- 캘린더를 구현하기 위해 작업했습니다.
- 캘린더 요일을 나타내는 부분에 취소선이 있었는데 삭제됐어요.

### 작업내용
- Hilt를 사용하기 위해 의존성을 추가했습니다.
   - 관련 의존성을 같이 추가했어요(compose viewmodel)
   - complie sdk 업데이트를 진행했습니다.
- InseoulApplication을 추가했습니다.
- #14 PR에서 누락된 함수를 추가했습니다.
   - 첫째 주, 마지막 주에 비어있는 요일만큼 일자를 가지고오는 함수입니다.
- CalendarScreen Composable을 추가했습니다.
   - 여기서 사용될 CalendarViewModel, CalendarDay, DayState도 함께 추가했습니다.
- CalendarToolbar, CalendarWeek의 속성들을 수정했습니다.

### 스크린샷
<img width="400" alt="스크린샷 2022-08-17 오전 10 55 29" src="https://user-images.githubusercontent.com/52733201/206752944-9595732b-085a-4792-80f9-d279a0c3732f.png">

### 테스트 방법
- app module 에서 calendar-library module 의존성을 추가한 후 MainActivity에서 CalendarScreen을 호출하면 캘린더가 노출되는지 확인합니다.
``` (MainActivity)
val viewModel: CalendarViewModel by viewModel()
//....
CalendarScreen(viewmodel)
```

### 리뷰노트
- 해당 PR을 더 분리했어야 했는데...🙏
- 캘린더 모듈에서 디자인 시스템 모듈 의존성을 추가하니 처음보는 에러가 나타났어요...추후 별도의 PR로 개선하겠습니다.
- 따라서, 캘린더 모듈의 색상은 하드코딩으로 넣어놨습니다.
