### PR TITLE
core-designsystem 모듈 의존성 추가 문제 해결하였습니다.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -54,6 +54,7 @@ android {
 
 dependencies {
     implementation(project(":library-calendar"))
+    implementation(project(":core:designsystem"))
 
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.1'

--- a/core/designsystem/build.gradle
+++ b/core/designsystem/build.gradle
@@ -31,6 +31,9 @@ android {
     buildFeatures {
         compose true
     }
+    composeOptions {
+        kotlinCompilerExtensionVersion '1.1.1'
+    }
 }
 
 dependencies {


### PR DESCRIPTION
### 배경
- core-designsystem 의존성 추가 시, 에러 발생 문제 해결을 위해 작업을 하게 되었습니다.

### 작업내용
- 제곧내.

### 리뷰노트
```kotlin
composeOptions {
        kotlinCompilerExtensionVersion '1.1.1'
    }
```
위의 코드 추가해주었습니다!
