### PR TITLE
임시로 만든 온보딩 인트로 화면을 볼 수 있습니다.

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -11,5 +11,7 @@
           </Key>
         </deviceKey>
       </Target>
+    </targetSelectedWithDropDown>
+    <timeTargetWasSelectedWithDropDown value="2022-12-12T09:35:57.695367Z" />
   </component>
 </project>

--- a/feature/onborading/build.gradle
+++ b/feature/onborading/build.gradle
@@ -47,6 +47,8 @@ dependencies {
 
     implementation "androidx.navigation:navigation-compose:$nav_version"
 
+    implementation "com.google.accompanist:accompanist-pager:0.23.1"
+
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.5.1"
     implementation "androidx.lifecycle:lifecycle-viewmodel-compose:2.5.1"
     implementation "androidx.hilt:hilt-navigation-compose:1.0.0"

--- a/feature/onborading/src/main/java/com/inseoul/onborading/OnBoardingRoute.kt
+++ b/feature/onborading/src/main/java/com/inseoul/onborading/OnBoardingRoute.kt
@@ -1,7 +1,5 @@
 package com.inseoul.onborading
 
-import androidx.compose.foundation.layout.Column
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -11,8 +9,5 @@ fun OnBoardingRoute(
     modifier: Modifier = Modifier,
     viewModel: OnBoardingViewModel = hiltViewModel()
 ) {
-    Column {
-        Text(text = "dddd")
-        Text(text = "ddddasdfasdfasdfasdf")
-    }
+    OnBoardingScreen()
 }

--- a/feature/onborading/src/main/java/com/inseoul/onborading/OnBoardingScreen.kt
+++ b/feature/onborading/src/main/java/com/inseoul/onborading/OnBoardingScreen.kt
@@ -1,0 +1,60 @@
+package com.inseoul.onborading
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.Surface
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccountBox
+import androidx.compose.material.icons.filled.AccountCircle
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.google.accompanist.pager.ExperimentalPagerApi
+import com.google.accompanist.pager.HorizontalPager
+import com.google.accompanist.pager.rememberPagerState
+import com.inseoul.onborading.screen.IntroScreen
+
+@OptIn(ExperimentalPagerApi::class)
+@Composable
+fun OnBoardingScreen(modifier: Modifier = Modifier) {
+    val pagerState = rememberPagerState()
+
+    Surface(modifier.fillMaxSize()) {
+        HorizontalPager(count = 3, state = pagerState) { page ->
+            when (page) {
+                0 -> {
+                    IntroScreen(
+                        title = "첫 번째 타이틀",
+                        description = "테스트11111",
+                        currentPagerIndex = 0,
+                        totalPagerCount = 3
+                    )
+                }
+                1 -> {
+                    IntroScreen(
+                        title = "타 이 틀 두 번 째 ",
+                        description = "one two three",
+                        currentPagerIndex = 1,
+                        totalPagerCount = 3
+                    )
+                }
+                else -> {
+                    TestScreen()
+                }
+            }
+        }
+    }
+}
+
+
+@Composable
+fun TestScreen() {
+    Column {
+        Image(imageVector = Icons.Default.AccountBox, contentDescription = null)
+        Image(imageVector = Icons.Default.AccountCircle, contentDescription = null)
+        Image(imageVector = Icons.Default.Add, contentDescription = null)
+        Image(imageVector = Icons.Default.ArrowBack, contentDescription = null)
+    }
+}

--- a/feature/onborading/src/main/java/com/inseoul/onborading/screen/IntroScreen.kt
+++ b/feature/onborading/src/main/java/com/inseoul/onborading/screen/IntroScreen.kt
@@ -1,0 +1,128 @@
+package com.inseoul.onborading.screen
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccountBox
+import androidx.compose.material.icons.filled.AccountCircle
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun IntroScreen(
+    modifier: Modifier = Modifier,
+    title: String,
+    description: String,
+    currentPagerIndex: Int,
+    totalPagerCount: Int
+) {
+    Column(
+        modifier = modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.SpaceBetween
+    ) {
+        Column {
+            IntroImage()
+            IntroInformation(
+                title = title,
+                description = description
+            )
+            IntroDot(
+                currentPagerIndex = currentPagerIndex,
+                totalPagerCount = totalPagerCount
+            )
+        }
+
+        IntroButton(
+            modifier = Modifier
+                .weight(1f, false),
+            currentPagerIndex = currentPagerIndex
+        )
+    }
+}
+
+@Composable
+fun IntroImage(modifier: Modifier = Modifier) {
+    Image(
+        modifier = modifier.size(360.dp),
+        imageVector = Icons.Default.AccountBox,
+        contentDescription = null
+    )
+}
+
+@Composable
+fun IntroInformation(
+    modifier: Modifier = Modifier,
+    title: String,
+    description: String
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(top = 36.dp, start = 16.dp, end = 16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = title,
+            fontWeight = FontWeight.Bold,
+            fontSize = 24.sp,
+            color = Color.Black,
+            textAlign = TextAlign.Center
+        )
+        Text(
+            text = description,
+            fontSize = 18.sp,
+            textAlign = TextAlign.Center
+        )
+    }
+}
+
+// NOTE : 임시로 Image로 해놨습니다.
+@Composable
+fun IntroDot(
+    modifier: Modifier = Modifier,
+    currentPagerIndex: Int,
+    totalPagerCount: Int
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(top = 32.dp),
+        horizontalArrangement = Arrangement.Center
+    ) {
+        for (i in 0 until totalPagerCount) {
+            Image(
+                imageVector = if (i == currentPagerIndex) {
+                    Icons.Default.AccountCircle
+                } else {
+                    Icons.Default.Add
+                },
+                contentDescription = "dot: $i"
+            )
+        }
+    }
+}
+
+// NOTE : 디자인시스템 버튼을 사용해야 합니다.
+@Composable
+fun IntroButton(
+    modifier: Modifier = Modifier,
+    currentPagerIndex: Int
+) {
+    Button(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(start = 16.dp, end = 16.dp, bottom = 24.dp),
+        onClick = { }
+    ) {
+        Text(text = if (currentPagerIndex == 0) "다음" else "고양이 이름 지어주기")
+    }
+}


### PR DESCRIPTION
### 배경
- 앱 실행 시 온보딩 화면을 노출해야 합니다.
- 현재 디자인시스템 에러와 디자인이 정확하게 나오지 않아 임시로 만들었습니다.
   - 버튼 클릭 시 화면만 이동해도 되나 유저 사용성을 높이기 위해 HorizontalPager를 사용하게 됐습니다.

### 작업내용
- pager compose 를 추가했습니다.
- IntroScreen을 추가했어요.
   - 현재 디자인 된 인트로 화면 1,2 가 재사용성이 높아서 하나로 만들었습니다. (IntroScreen)
- OnBoardingScreen에 HorizontalPager를 추가했습니다. 

### 스크린샷

https://user-images.githubusercontent.com/52733201/208158337-d09aa879-cba2-4079-93c2-f133721c7def.mp4

### 리뷰노트
- 컴포즈 윽...😂
