### PR TITLE
캘린더 화면에서 이전 달, 다음 달 클릭 시 해당 월의 캘린더를 볼 수 있습니다.

### DIFF
--- a/feature/calendar/src/main/java/com/treemiddle/calendar/screen/CalendarRoute.kt
+++ b/feature/calendar/src/main/java/com/treemiddle/calendar/screen/CalendarRoute.kt
@@ -1,14 +1,29 @@
 package com.treemiddle.calendar.screen
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.ExperimentalLifecycleComposeApi
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.inseoul.library_calendar.CalendarViewModel
 
+@OptIn(ExperimentalLifecycleComposeApi::class)
 @Composable
 fun CalendarRoute(
     modifier: Modifier = Modifier,
     viewModel: CalendarViewModel = hiltViewModel()
 ) {
-    CalendarScreen(viewModel = viewModel)
+    val dayStateList by viewModel.calendarState.collectAsStateWithLifecycle()
+    val calendarTitle by viewModel.calendarTitle.collectAsStateWithLifecycle()
+
+     CalendarScreen(
+         dayStateList = dayStateList,
+         currentTitle = calendarTitle,
+         onBackButtonClicked = {
+             // 이전 화면으로 이동해야 합니다.
+         },
+         onPreviousClicked =  { viewModel.onPreviousClick() },
+         onNextClicked = { viewModel.onNextClick() }
+     )
 }

--- a/feature/calendar/src/main/java/com/treemiddle/calendar/screen/CalendarRoute.kt
+++ b/feature/calendar/src/main/java/com/treemiddle/calendar/screen/CalendarRoute.kt
@@ -1,5 +1,6 @@
 package com.treemiddle.calendar.screen
 
+import android.widget.Toast
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -24,6 +25,13 @@ fun CalendarRoute(
              // 이전 화면으로 이동해야 합니다.
          },
          onPreviousClicked =  { viewModel.onPreviousClick() },
-         onNextClicked = { viewModel.onNextClick() }
+         onNextClicked = { viewModel.onNextClick() },
+         onOutSideClicked = { isShownNextMonth, _ ->
+             if (isShownNextMonth) {
+                 viewModel.onNextClick()
+             } else {
+                 viewModel.onPreviousClick()
+             }
+         }
      )
 }

--- a/feature/calendar/src/main/java/com/treemiddle/calendar/screen/CalendarScreen.kt
+++ b/feature/calendar/src/main/java/com/treemiddle/calendar/screen/CalendarScreen.kt
@@ -12,12 +12,16 @@ import com.inseoul.designsystem.icon.InseoulIcons.ArrowBack
 import com.inseoul.designsystem.toolbar.InseoulToolbar
 import com.inseoul.library_calendar.CalendarDay
 import com.inseoul.library_calendar.CalendarToolbar
-import com.inseoul.library_calendar.CalendarViewModel
 import com.inseoul.library_calendar.CalendarWeek
+import com.inseoul.library_calendar.DayState
 
 @Composable
 fun CalendarScreen(
-    viewModel: CalendarViewModel
+    dayStateList: List<DayState>,
+    currentTitle: String,
+    onBackButtonClicked: () -> Unit,
+    onPreviousClicked: () -> Unit,
+    onNextClicked: () -> Unit
 ) {
     Column(
         modifier = Modifier
@@ -29,27 +33,21 @@ fun CalendarScreen(
             modifier = Modifier,
             title = "캘린더",
             backButtonImageResource = ArrowBack,
-            onImageClicked = {
-                // NOTE : 툴바 뒤로가기
-            }
+            onImageClicked = { onBackButtonClicked() }
         )
         CalendarToolbar(
-            title = "2022년 12월",
-            onPreviousClicked = {
-                // NOTE : 이전 달로 이동해야 합니다.
-            },
-            onNextClicked = {
-                // NOTE : 다음 달로 이동해야 합니다.
-            }
+            title = currentTitle,
+            onPreviousClicked = { onPreviousClicked() },
+            onNextClicked = { onNextClicked() }
         )
         CalendarWeek()
         LazyVerticalGrid(
             columns = GridCells.Fixed(7)
         ) {
-            items(viewModel.getCalendarDays().size) {
+            items(dayStateList.size) {
                 CalendarDay(
-                    day = viewModel.getCalendarDays()[it].day,
-                    isActivated = viewModel.getCalendarDays()[it].isActivated
+                    day = dayStateList[it].day,
+                    isActivated = dayStateList[it].isActivated
                 )
             }
         }

--- a/feature/calendar/src/main/java/com/treemiddle/calendar/screen/CalendarScreen.kt
+++ b/feature/calendar/src/main/java/com/treemiddle/calendar/screen/CalendarScreen.kt
@@ -21,7 +21,8 @@ fun CalendarScreen(
     currentTitle: String,
     onBackButtonClicked: () -> Unit,
     onPreviousClicked: () -> Unit,
-    onNextClicked: () -> Unit
+    onNextClicked: () -> Unit,
+    onOutSideClicked: (Boolean, Int) -> Unit
 ) {
     Column(
         modifier = Modifier
@@ -45,9 +46,20 @@ fun CalendarScreen(
             columns = GridCells.Fixed(7)
         ) {
             items(dayStateList.size) {
+                val day = dayStateList[it].day
+                val isActivated = dayStateList[it].isActivated
+                val isShownNextMonth = day.toInt() in 1..7
+
                 CalendarDay(
-                    day = dayStateList[it].day,
-                    isActivated = dayStateList[it].isActivated
+                    day = day,
+                    isActivated = isActivated,
+                    onDayClicked = {
+                        if (isActivated) {
+                            // NOTE : 해당 요일의 데이터를 가져와야 합니다.
+                        } else {
+                            onOutSideClicked(isShownNextMonth, day.toInt())
+                        }
+                    }
                 )
             }
         }

--- a/library-calendar/build.gradle
+++ b/library-calendar/build.gradle
@@ -43,15 +43,16 @@ android {
 
 dependencies {
     api project(":core:designsystem")
+    api project(":core:common")
 
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.4'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.0'
     
     api 'androidx.lifecycle:lifecycle-runtime-compose:2.6.0-alpha03'
-    implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.5.1"
-    implementation "androidx.lifecycle:lifecycle-viewmodel-compose:2.5.1"
-    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.0-alpha03"
+    api "androidx.lifecycle:lifecycle-runtime-ktx:2.5.1"
+    api "androidx.lifecycle:lifecycle-viewmodel-compose:2.5.1"
+    api "androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.0-alpha03"
 
     implementation "com.google.dagger:hilt-android:2.44"
     kapt "com.google.dagger:hilt-compiler:2.44"

--- a/library-calendar/src/main/java/com/inseoul/library_calendar/CalendarDay.kt
+++ b/library-calendar/src/main/java/com/inseoul/library_calendar/CalendarDay.kt
@@ -1,5 +1,6 @@
 package com.inseoul.library_calendar
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -14,10 +15,13 @@ import androidx.compose.ui.unit.dp
 @Composable
 fun CalendarDay(
     day: String,
-    isActivated: Boolean
+    isActivated: Boolean,
+    onDayClicked: () -> Unit
 ) {
     Text(
-        modifier = Modifier.size(size = 40.dp),
+        modifier = Modifier
+            .size(size = 40.dp)
+            .clickable { onDayClicked() },
         text = day,
         color = if (isActivated) {
             Color(0xFF212124)

--- a/library-calendar/src/main/java/com/inseoul/library_calendar/CalendarViewModel.kt
+++ b/library-calendar/src/main/java/com/inseoul/library_calendar/CalendarViewModel.kt
@@ -1,22 +1,37 @@
 package com.inseoul.library_calendar
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.common.Constants.Companion.EMPTY_STRING
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class CalendarViewModel @Inject() constructor() : ViewModel() {
     private var calendarHelper = CalendarHelper()
-
     private val days = mutableListOf<DayState>()
+
+    var calendarState = MutableStateFlow<List<DayState>>(emptyList())
+        private set
+
+    var calendarTitle = MutableStateFlow(EMPTY_STRING)
+        private set
 
     init {
         initalized()
     }
 
-    fun getCalendarDays(): List<DayState> = days
-
-    fun getCalendarToolbarTitle(): String = calendarHelper.getCurrentYearAndMonth()
+    fun onPreviousClick() {
+        calendarHelper.previousMonth()
+        initalized()
+    }
+    fun onNextClick() {
+        calendarHelper.nextMonth()
+        initalized()
+    }
 
     private fun initalized() {
         val currentDays = calendarHelper.createCalendar()
@@ -28,6 +43,8 @@ class CalendarViewModel @Inject() constructor() : ViewModel() {
         addDaysIfNeeded(daysOfPreviousMonth)
         addDaysIfNeeded(currentDays, true)
         addDaysIfNeeded(daysOfNextMonth)
+
+        loadCalendarUi()
     }
 
     private fun getLastWeekDayEmptyCount(): Int = calendarHelper.getLastWeekDayEmptyCount()
@@ -40,6 +57,8 @@ class CalendarViewModel @Inject() constructor() : ViewModel() {
     private fun getFirstDaysOfNextMonth(emptyCount: Int): List<Int> =
         calendarHelper.getFirstDaysOfNextMonth(emptyCount)
 
+    private fun getCalendarToolbarTitle(): String = calendarHelper.getCurrentYearAndMonth()
+
     private fun addDaysIfNeeded(dayList: List<Int>, isNeeded: Boolean = false) {
         if (dayList.isEmpty()) return
 
@@ -50,6 +69,27 @@ class CalendarViewModel @Inject() constructor() : ViewModel() {
                     isActivated = isNeeded
                 )
             )
+        }
+    }
+
+    private fun clearDays() = days.clear()
+
+    private fun loadCalendarUi() {
+        emitCalendarTitle()
+        emitDayState(days)
+    }
+
+    private fun emitDayState(dayStateList: List<DayState>) {
+        viewModelScope.launch {
+            calendarState.emit(dayStateList)
+            delay(10) // NOTE : 이쪽 로직은 조금 더 생각해봐야 합니다. (컴포즈 원리)
+            clearDays()
+        }
+    }
+
+    private fun emitCalendarTitle() {
+        viewModelScope.launch {
+            calendarTitle.emit(getCalendarToolbarTitle())
         }
     }
 }


### PR DESCRIPTION
### 배경
- 캘린더 화면에서 이전, 다음 달의 해당하는 일을 볼 수 있어야합니다.

### 작업내용
- 라이브러리 캘린더 모듈에서 gradle 속성을 변경했습니다.
- CalendarRoute에서 ViewModel property hoisting을 작업했습니다.
- CalendarViewModel에서 onPrevisouClick(), onNextClick()을 추가했습니다.
- 사용자 편의성을 위해 현재 월의 일이 아닌 다른 월의 일을 클릭 시 이전, 다음 달로 넘어가도록 작업했습니다.

### 스크린샷

https://user-images.githubusercontent.com/52733201/208289302-860af07e-0f12-4b38-8818-ac1be26a9537.mp4



### 리뷰노트
- LazyVerticalGrid 에서 Text가 그려질 때 Animation 적용해보려고 했는데 컴린이라 쉽지 않네요...(다음에 도전 해볼게요)
- CalendarViewModel에 recomposition조건을 아직 정확하게 몰라서 delay을 줘 days를 clear()해줬어요.
   - 이 부분을 확인 후 수정해놓을게요.
- 아직 캘린더 100프로 작업이 아닙니다. 가끔 7주까지 나오는 경우도 있는데 이 부분도 수정해놓을게요.
